### PR TITLE
Code to configure syslog server for barnyard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ For more details on using OnionSalt in your Security Onion see the [Security Oni
 - Mike Reeves ([TOoSmOotH](https://twitter.com/TOoSmOotH)) BSides August 2014 Talk - [Scaling Security Onion to the Enterprise](https://www.youtube.com/watch?v=hHhxVQxj3aY)
 - [Security Onion Blog](http://blog.securityonion.net/) and the related [OnionSalt Blog Posts](http://blog.securityonion.net/search/label/onionsalt)
 
-### Changlog
+### Changelog
+
+Version 1.1.5:
+
+	- Manage the barnyard configuration file for to syslog across all of the sensors.
 
 Version 1.1.4:
 

--- a/opt/onionsalt/pillar/barnyard-conf.sls.template
+++ b/opt/onionsalt/pillar/barnyard-conf.sls.template
@@ -1,0 +1,15 @@
+################################################################################
+#                            BARNYARD-CONF PILLAR
+#
+# This won't run until you set enabled to 'yes' (without quotes).
+#
+################################################################################
+
+{% set barnyard_conf_syslog_port     = '514' %}
+{% set barnyard_conf_syslog_protocol = 'udp' %}
+
+barnyard-conf:
+  syslog_port: {{ barnyard_conf_syslog_port }}
+  syslog_protocol: {{ barnyard_conf_syslog_protocol }}
+  syslog_server: 'yoursyslogserverhere.example.com'
+  enabled: no

--- a/opt/onionsalt/pillar/top.sls
+++ b/opt/onionsalt/pillar/top.sls
@@ -9,3 +9,4 @@
 base:
   '*':
     - users
+    - barnyard-conf

--- a/opt/onionsalt/salt/sensor/barnyard-conf/init.sls
+++ b/opt/onionsalt/salt/sensor/barnyard-conf/init.sls
@@ -1,0 +1,79 @@
+#############################
+##                         ##
+##    BARNYARD-CONF SLS    ##
+##                         ##
+#############################
+
+################################################################################
+#!!!!!!!!!!                                                        !!!!!!!!!!!!!
+#          See /opt/onionsalt/pillar/barnyard-conf.sls for details,
+#                all configuration happens in that pillar.
+#                    No need to change anything here.
+#!!!!!!!!!!                                                        !!!!!!!!!!!!!
+################################################################################
+
+{% if pillar['barnyard-conf']['enabled'] %}
+
+# Variables we are using - get them into some easier/shorter names.
+{% set syslog_server   = pillar['barnyard-conf']['syslog_server'] %}
+{% set syslog_port     = pillar['barnyard-conf']['syslog_port'] %}
+{% set syslog_protocol = pillar['barnyard-conf']['syslog_protocol'] %}
+{% set nodename        = grains['nodename'] %}
+
+# SOSETUP defaults to half_cpus, we check if a grain has been defined and if it
+# has use that, if no, just set the lb_procs to have the CPUs. The number of
+# barnyard processes on each sensor equals lb_procs.
+{% set half_cpus = (grains['num_cpus']/2)|round|int %}
+{% if grains['ids_lb_procs'] is defined %}
+{% set lb_procs = grains['ids_lb_procs'] %}
+{% else %}
+{% set lb_procs = half_cpus %}
+{% endif %}
+
+# Check if the sensor_interface grain is defined, otherwise just assume we are
+# only listening on eth1.
+{% if grains['sensor_interfaces'] is defined %}
+{% set sensor_interfaces = grains['sensor_interfaces'] %}
+{% else %}
+{% set sensor_interfaces = ['eth1'] %}
+{% endif %}
+
+{% for interface in sensor_interfaces %}
+{% set sensorname = '{0}-{1}'.format(nodename, interface) %}
+
+{{ sensorname }}-barnyard2-conf:
+  file.blockreplace:
+    - name: /etc/nsm/{{ sensorname }}/barnyard2.conf
+    - marker_start: "# Begin Onionsalt awesomeness"
+    - marker_end: "# Done Onionsalt awesomeness."
+    - append_if_not_found: True
+    - content: |
+        output alert_syslog_full: sensor_name {{ sensorname }}, server {{ syslog_server }}, protocol udp, port 514, operation_mode default
+
+{% for ids_worker in range(1, (1+lb_procs)) %}
+barnyard-{{ sensorname }}-{{ ids_worker }}-conf:
+  file.blockreplace:
+    - name: /etc/nsm/{{ sensorname }}/barnyard2-{{ ids_worker }}.conf
+    - marker_start: "# Begin Onionsalt awesomeness"
+    - marker_end: "# Done Onionsalt awesomeness."
+    - append_if_not_found: True
+    - content: |
+        output alert_syslog_full: sensor_name {{ sensorname }}, server {{ syslog_server }}, protocol {{ syslog_protocol }}, port {{ syslog_port }}, operation_mode default
+
+{% endfor %}
+{% endfor %}
+
+restart-barnyard-and-workers:
+  cmd.wait:
+    - name: /usr/sbin/nsm_sensor_ps-restart --only-barnyard2
+    - cwd: /
+    - watch:
+{% for interface in sensor_interfaces %}
+{% set sensorname = '{0}-{1}'.format(nodename, interface) %}
+      - file: /etc/nsm/{{ sensorname }}/barnyard2.conf
+{% for ids_worker in range(1, (1+lb_procs)) %}
+      - file: /etc/nsm/{{ sensorname }}/barnyard2-{{ ids_worker }}.conf
+{% endfor %}
+{% endfor %}
+
+{% endif %}

--- a/opt/onionsalt/salt/sensor/init.sls
+++ b/opt/onionsalt/salt/sensor/init.sls
@@ -4,9 +4,12 @@
 ##               ##
 ###################
 
-# Uncomment to enable central bpf_configuration. Be sure to read ./bpf/init.sls
-#include:
-#- .bpf
+# Uncomment to enable central bpf_configuration.
+# Be sure to read ./bpf/init.sls and/or pillar/barnyard-conf/init.sls
+# Barnyard-conf is enabled/disabled in pillar/barnyard-conf.sls
+include:
+#  - .bpf
+  - .barnyard-conf
 
 # Add the Repo
 sensor:


### PR DESCRIPTION
This salt state and corresponding pillar will allow a user to configure all barnyard instances on a sensor to send to a syslog server. Will also restart the barnyard processes when changing the files.

Won't run unless `enabled: yes` is set in the corresponding pillar.