### PR TITLE
sync Snort VRT .so files in /usr/local/lib/snort_dynamicrules/

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ For more details on using OnionSalt in your Security Onion see the [Security Oni
 
 ### Changlog
 
+Version 1.1.5:
+
+	- Sync Snort VRT .so files from /usr/local/lib/snort_dynamicrules
+
 Version 1.1.4:
 
 	- Minor modification to how the bpf management gets a list of interfaces to

--- a/opt/onionsalt/VERSION.txt
+++ b/opt/onionsalt/VERSION.txt
@@ -1,1 +1,1 @@
-Version: 1.1.4
+Version: 1.1.5

--- a/opt/onionsalt/salt/backend/init.sls
+++ b/opt/onionsalt/salt/backend/init.sls
@@ -28,6 +28,12 @@ securityonion-all:
    file.symlink:
      - target: /etc/nsm/rules
 
+# Create the symlink to replicate /usr/local/lib/snort_dynamicrules/
+
+/opt/onionsalt/salt/sensor/snort_dynamicrules:
+   file.symlink:
+     - target: /usr/local/lib/snort_dynamicrules/
+
 # Create directory for Bro intel feeds
 
 brointel:

--- a/opt/onionsalt/salt/sensor/init.sls
+++ b/opt/onionsalt/salt/sensor/init.sls
@@ -36,12 +36,20 @@ rule-sync:
      - maxdepth: 0
      - source: salt://sensor/rules
 
+dynamicrule-sync:
+   file.recurse:
+     - name: /usr/local/lib/snort_dynamicrules
+     # Don't mess with maxdepth or you will go on a recursed loop of pain
+     - maxdepth: 0
+     - source: salt://sensor/snort_dynamicrules
+
 restart-ids:
   cmd.wait:
     - name: /usr/sbin/nsm_sensor_ps-restart --only-snort-alert
     - cwd: /
     - watch:
       - file: /etc/nsm/rules
+      - file: /usr/local/lib/snort_dynamicrules
       
 restart-barnyard:
   cmd.wait:
@@ -49,6 +57,7 @@ restart-barnyard:
     - cwd: /
     - watch:
       - file: /etc/nsm/rules
+      - file: /usr/local/lib/snort_dynamicrules
 
 ## End IDS Section
 


### PR DESCRIPTION
If a user is running the Snort engine with the Sourcefire VRT ruleset, then PulledPork stores the .so files in /usr/local/lib/snort_dynamicrules/.  We need to replicate this directory from the master server to the sensors.
