### PR TITLE
Move sudoers config to /etc/sudoers.d/

### DIFF
--- a/opt/onionsalt/salt/sudo/init.sls
+++ b/opt/onionsalt/salt/sudo/init.sls
@@ -7,5 +7,5 @@
 # Make it so the sudo group can run sudo commands without a password since we are using key auth
 sudoers:
   file.append:
-    - name: /etc/sudoers
+    - name: /etc/sudoers.d/securityonion-onionsalt
     - text: "%sudo ALL=(ALL) NOPASSWD: ALL"


### PR DESCRIPTION
We need to avoid modifying the default /etc/sudoers and instead add our modifications to /etc/sudoers.d/securityonion-onionsalt.